### PR TITLE
Directly join origins to avoid postgres overload

### DIFF
--- a/app/models/noise.rb
+++ b/app/models/noise.rb
@@ -30,13 +30,9 @@ class Noise < ActiveRecord::Base
     dependent: :destroy
 
   scope :where_nearby, ->(params) do
-    noise_ids = Origin.explore(params).
-      where_since(params[:created_at]).
-      map &:noise_id
-
-    Rails.logger.debug "#{noise_ids.count} noises found from exploring origins"
-
-    where(id: noise_ids).order_by_ids(noise_ids)
+    joins(:origins).
+      merge(Origin.explore(params)).
+      where_since(params[:created_at])
   end
 
   scope :where_needs_triage, ->(params) do


### PR DESCRIPTION
Solves the 

> PG::ProgramLimitExceedednoises#index
> ERROR: target lists can have at most 1664 entries

error